### PR TITLE
Improvements to data grid performance and responsiveness

### DIFF
--- a/src/frontend/ui/components/grid-cell.component.tsx
+++ b/src/frontend/ui/components/grid-cell.component.tsx
@@ -16,7 +16,7 @@ import { DataGridCell } from './grid.component';
 export const TextCell: DataGridCell<string> = ({ value }) => <>{value}</>;
 
 TextCell.width = (data, fontSize) =>
-  Math.max(400, Math.min(600, data ? data.length * fontSize : 300));
+  Math.max(100, Math.min(600, data ? data.length * fontSize * 0.4 : 300));
 
 /** Datagrid cell for indicating progress */
 export const ProgressCell: DataGridCell<ProgressValue> = ({ value }) => (
@@ -49,4 +49,4 @@ export const ReferenceCell: DataGridCell<string> = ({ value, property }) => {
 };
 
 ReferenceCell.width = (data, fontSize) =>
-  Math.max(200, Math.min(600, data ? data.length * fontSize : 300));
+  Math.max(100, Math.min(600, data ? data.length * fontSize * 0.4 : 300));

--- a/src/frontend/ui/components/grid.component.tsx
+++ b/src/frontend/ui/components/grid.component.tsx
@@ -309,7 +309,7 @@ function CellWrapper<T extends Resource>({
   const { current: selection, setSelection } = SelectionContext.useContainer();
   const colData = cursor.get(rowIndex);
   const column = columns[columnIndex];
-  const plainBg = rowIndex % 2 === 0 ? 'background' : 'foreground';
+  const plainBg = rowIndex % 2 === 1 ? 'background' : 'foreground';
   const selected = selection && selection === colData?.id;
 
   const sx: ThemeUIStyleObject = {

--- a/src/frontend/ui/components/grid.component.tsx
+++ b/src/frontend/ui/components/grid.component.tsx
@@ -401,8 +401,11 @@ const GridWrapper = forwardRef<HTMLDivElement, HTMLAttributes<unknown>>(
                       e.clientX;
                   }}
                   onDrag={(e) => {
-                    if (e.clientX >= 0) {
-                      onResize(i, dragWidth.current + e.clientX);
+                    const newSize = dragWidth.current + e.clientX;
+
+                    // Why does the final dragend report a clientwidth of 0?
+                    if (e.clientX > 0 && newSize >= 36) {
+                      onResize(i, newSize);
                     }
                   }}
                 ></div>

--- a/src/frontend/ui/components/grid.component.tsx
+++ b/src/frontend/ui/components/grid.component.tsx
@@ -72,8 +72,6 @@ export function DataGrid<T extends Resource>({
       return;
     }
 
-    console.log('set column sizes');
-
     setColumnSizes((prev) => {
       if (prev) {
         return prev;
@@ -187,6 +185,13 @@ export function DataGrid<T extends Resource>({
       <AutoSizer
         onResize={(size) => {
           viewSize.current = size;
+
+          // Resize the trailing grid item
+          if (columns.length === 1) {
+            gridRef?.current?.resetAfterColumnIndex(0);
+          } else {
+            gridRef?.current?.resetAfterColumnIndex(columns.length);
+          }
         }}
       >
         {({ height, width }) => {
@@ -226,9 +231,22 @@ export function DataGrid<T extends Resource>({
                     }}
                     width={width}
                     height={height}
-                    columnWidth={(i) => columnSizes[i]}
+                    columnWidth={(i) => {
+                      if (columns.length === 1) {
+                        return width;
+                      }
+
+                      if (i < columns.length) {
+                        return columnSizes[i];
+                      }
+
+                      const lastOffset = last(columnOffsets);
+                      return lastOffset ? width - lastOffset : 0;
+                    }}
                     rowCount={data.totalCount}
-                    columnCount={columns.length}
+                    columnCount={
+                      columns.length > 1 ? columns.length + 1 : columns.length
+                    }
                     rowHeight={() => rowHeight}
                     itemData={dataVal}
                     outerRef={outerListRef}
@@ -374,9 +392,12 @@ const GridWrapper = forwardRef<HTMLDivElement, HTMLAttributes<unknown>>(
                   textOverflow: 'ellipsis',
                   top: '0',
                   height: rowHeight,
-                  width: columnSizes[i],
+                  width: columns.length === 1 ? '100%' : columnSizes[i],
                   left: columnOffsets[i],
-                  borderRight: '1px solid var(--theme-ui-colors-border)',
+                  borderRight:
+                    columns.length === 1
+                      ? 'none'
+                      : '1px solid var(--theme-ui-colors-border)',
                   borderBottom: '1px solid var(--theme-ui-colors-border)',
                   textAlign: 'center'
                 }}


### PR DESCRIPTION
Improves performance of the grid view and fix various sizing issues for columns.

Specifically, we:

* Move from using a js-based scroll-sync for positioning sticky headers to doing it natively in the browser via `position: sticky`. Found an override point in react-window to support this.
* Tweak the initial sizes of columns to prefer slightly larger widths.
* Move from using react-window's `VariableSizedGrid` to `FixedSizedList` and don't virtualize the grid columns. This is unnecessary for the number of columns we have and made allowing user-resized grid columns quite difficult and stuttery.

This was partially released in v0.2 (the first bullet point above). This PR is open to get the fix into main and resolve issues noticed in v0.2.
