### PR TITLE
Support editing metadata for imported assets

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -19,7 +19,11 @@
 
   "forwardPorts": [6080, 5901, 5858, 9223],
 
-  "extensions": ["dbaeumer.vscode-eslint", "esbenp.prettier-vscode"],
+  "extensions": [
+    "dbaeumer.vscode-eslint",
+    "esbenp.prettier-vscode",
+    "Orta.vscode-jest"
+  ],
 
   "postCreateCommand": "yarn install",
 

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -32,6 +32,9 @@
       "disableOptimisticBPs": true,
       "cwd": "${workspaceFolder}",
       "runtimeExecutable": "yarn",
+      "env": {
+        "NO_OVERRIDE_TIMEOUTS": "true"
+      },
       "args": [
         "jest",
         "--runInBand",

--- a/src/app/ingest/asset-ingest.operation.ts
+++ b/src/app/ingest/asset-ingest.operation.ts
@@ -144,6 +144,8 @@ export class AssetIngestOperation implements IngestSession {
       return;
     }
 
+    this.collectionService.on('change', this.handleCollectionChanged);
+
     this._active = true;
 
     this.log.info('Starting session');
@@ -169,6 +171,7 @@ export class AssetIngestOperation implements IngestSession {
    * Abort any pending tasks for the ingest operation.
    **/
   async teardown() {
+    this.collectionService.off('change', this.handleCollectionChanged);
     this._active = false;
   }
 
@@ -566,6 +569,11 @@ export class AssetIngestOperation implements IngestSession {
       session: this
     });
   }
+
+  private handleCollectionChanged = async () => {
+    await this.revalidate();
+    this.emitStatus();
+  };
 }
 
 /**

--- a/src/app/ingest/asset-ingest.service.ts
+++ b/src/app/ingest/asset-ingest.service.ts
@@ -288,6 +288,7 @@ export class AssetIngestService extends EventEmitter<Events> {
 interface Events {
   status: [ImportStateChanged];
   importRunCompleted: [AssetIngestOperation];
+  edit: [ImportStateChanged];
 }
 
 /**

--- a/src/common/ingest.interfaces.ts
+++ b/src/common/ingest.interfaces.ts
@@ -120,6 +120,25 @@ export const ListIngestSession = RpcInterface({
 });
 
 /**
+ * List all ingest sessions in an archive.
+ **/
+export const UpdateIngestedMetadata = RpcInterface({
+  id: 'ingest/edit-metadata',
+  request: z.object({
+    assetId: z.string(),
+    sessionId: z.string(),
+    metadata: z.record(z.unknown())
+  }),
+  response: z.object({})
+});
+export type UpdateIngestedMetadataRequest = RequestType<
+  typeof UpdateIngestedMetadata
+>;
+export type UpdateIngestedMetadataResponse = ResponseType<
+  typeof UpdateIngestedMetadata
+>;
+
+/**
  * Complete the ingest session.
  *
  * Moves the assets in the ingest session `sessionId` into the main database and deletes the session.

--- a/src/frontend/screens/ingest.screen.tsx
+++ b/src/frontend/screens/ingest.screen.tsx
@@ -67,6 +67,9 @@ export const ArchiveIngestScreen: FC = () => {
         asset={selectedAsset}
         sx={{ width: '100%', height: '100%' }}
         collection={collection.value}
+        errors={selectedAsset.validationErrors ?? undefined}
+        sessionId={sessionId}
+        action="import"
       />
     ) : undefined;
 

--- a/src/frontend/ui/components/page-layouts.component.tsx
+++ b/src/frontend/ui/components/page-layouts.component.tsx
@@ -324,6 +324,7 @@ export const PrimaryDetailLayout: FC<
   return (
     <ReflexContainer
       sx={{
+        minHeight: 0,
         '&.reflex-container.vertical > .reflex-splitter': {
           borderRight: '1px solid var(--theme-ui-colors-border)',
           borderLeft: 'none',
@@ -348,7 +349,11 @@ export const PrimaryDetailLayout: FC<
 
       {detail && (
         <ReflexElement
-          sx={{ display: 'flex', flexDirection: 'column', height: '100vh' }}
+          sx={{
+            display: 'flex',
+            flexDirection: 'column',
+            position: 'relative'
+          }}
           flex={0.25}
           minSize={320}
         >

--- a/src/frontend/ui/components/schema-form.component.tsx
+++ b/src/frontend/ui/components/schema-form.component.tsx
@@ -1,11 +1,10 @@
 /** @jsxImportSource theme-ui */
 
 import { ChangeEvent, FC, useCallback } from 'react';
-import { Box, BoxProps, Field, Label, Text, Textarea } from 'theme-ui';
+import { Box, BoxProps, Field, Label, Text } from 'theme-ui';
 import {
   GetAsset,
   GetCollection,
-  GetRootDatabaseCollection,
   SchemaProperty,
   SchemaPropertyType,
   SearchAsset
@@ -145,6 +144,8 @@ export const DatabaseReferenceField: FC<SchemaFormFieldProps<string>> = ({
     );
   }
 
+  // If we don't have a result for the referenced value (because it is invalid or not fetched yet)
+  // then at least return the header
   if (referencedValue?.status !== 'ok' || !titleKey) {
     return (
       <Box {...props}>

--- a/src/frontend/ui/components/schema-form.component.tsx
+++ b/src/frontend/ui/components/schema-form.component.tsx
@@ -146,7 +146,11 @@ export const DatabaseReferenceField: FC<SchemaFormFieldProps<string>> = ({
   }
 
   if (referencedValue?.status !== 'ok' || !titleKey) {
-    return null;
+    return (
+      <Box {...props}>
+        <Label>{property.label}</Label>
+      </Box>
+    );
   }
 
   return (


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Adds support for editing the metadata of imported assets.

## Motivation and Context
It's common for imported assets to have some validation errors, especially in large imports. This PR adds support for editing the metadata of imported assets using the same UI that is used to administer assets in the archive.

This feature was released in preview v0.2. This PR merges those changes into main, adding tests and documenting the code.